### PR TITLE
Translate a slave vocabulary managed by a master field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Translate the "select" slave field terms if possible (like "No value").
+  [sgeulette]
 
 
 1.4.1 (2014-10-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Translate the "select" slave field terms if possible (like "No value").
+- Translate the "vocabulary" slave field terms (like "No value") when entire vocabulary is replaced.
   [sgeulette]
 
 

--- a/plone/formwidget/masterselect/configure.zcml
+++ b/plone/formwidget/masterselect/configure.zcml
@@ -7,6 +7,7 @@
 
     <!-- Include our dependencies -->
     <includeDependencies package="." />
+    <include package="Products.CMFCore" file="permissions.zcml" />
     <include file="upgrade.zcml" />
 
     <adapter factory=".widget.MasterSelectFieldWidget" />

--- a/plone/formwidget/masterselect/demo.py
+++ b/plone/formwidget/masterselect/demo.py
@@ -249,7 +249,6 @@ class IMasterSelectDemo(model.Schema):
              'action': 'vocabulary',
              'vocab_method': getSlaveVocab3,
              'control_param': 'master',
-             'initial_trigger': True,
              },
         ),
         required=True,

--- a/plone/formwidget/masterselect/demo.py
+++ b/plone/formwidget/masterselect/demo.py
@@ -29,6 +29,10 @@ def getSlaveVocab2(master):
     return results
 
 
+def getSlaveVocab3(master):
+    return [master]
+
+
 def getSlaveValue(master):
     """Value function that returns ROT13 transformed input."""
     numeric = ord(master)
@@ -233,4 +237,28 @@ class IMasterSelectDemo(model.Schema):
                       u'selected in masterBoolean. It will become visible '
                       u'only when that checkbox is checked.'),
         required=False,
+    )
+
+    masterField4 = MasterSelectField(
+        title=_(u'MasterField 4'),
+        description=_(u'This field controls the vocabulary of slaveField7.'
+                      u'The selected value becomes the value of slaveField7.'),
+        values=('ok', 'nok'),
+        slave_fields=(
+            {'name': 'slaveField7',
+             'action': 'vocabulary',
+             'vocab_method': getSlaveVocab3,
+             'control_param': 'master',
+             'initial_trigger': True,
+             },
+        ),
+        required=True,
+    )
+
+    slaveField7 = schema.Choice(
+        title=_(u'SlaveField7'),
+        description=_(u'This field\'s value is controlled by the value '
+                      u'selected in masterBoolean.'),
+        required=False,
+        values=('ok', 'nok')
     )

--- a/plone/formwidget/masterselect/testing.py
+++ b/plone/formwidget/masterselect/testing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
+from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -24,7 +24,6 @@ class MasterSelectLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.formwidget.masterselect:demo')
 
-
 PLONE_FORMWIDGET_MASTERSELECT = MasterSelectLayer()
 PLONE_FORMWIDGET_MASTERSELECT_INTEGRATION = IntegrationTesting(
     name='plone.formwidget.masterselect:Integration',
@@ -34,6 +33,6 @@ PLONE_FORMWIDGET_MASTERSELECT_FUNCTIONAL = FunctionalTesting(
     bases=(PLONE_FORMWIDGET_MASTERSELECT, ))
 PLONE_FORMWIDGET_MASTERSELECT_ROBOT = FunctionalTesting(
     name='plone.formwidget.masterselect:Robot',
-    bases=(AUTOLOGIN_LIBRARY_FIXTURE,
+    bases=(REMOTE_LIBRARY_BUNDLE_FIXTURE,
            PLONE_FORMWIDGET_MASTERSELECT,
            z2.ZSERVER_FIXTURE))

--- a/plone/formwidget/masterselect/tests/robot/test_masterselect_demo.robot
+++ b/plone/formwidget/masterselect/tests/robot/test_masterselect_demo.robot
@@ -72,8 +72,10 @@ Scenario: Master boolean field toggles visibility of slave field
 Scenario: Master select field controls slave field vocabulary. Check if value is well translated.
     Set default language  fr
     Given I am on the masterselect demo page as a Manager
-     When I select 'ok' on master field 'form-widgets-masterField4'
-     Then Slave field '7' vocabulary should have text values Aucune valeur,ok
+     Then Slave field '7' vocabulary should '' have text values Aucune valeur,ok,nok
+     When I select 'nok' on master field 'form-widgets-masterField4'
+     Then Slave field '7' vocabulary should '' have text values Aucune valeur,nok
+     And Slave field '7' vocabulary should 'not' have text values ok
     
 
 *** Keywords ***
@@ -102,10 +104,10 @@ Slave field '${id}' vocabulary should have values ${possible_values}
     :FOR    ${i}    in    @{ITEMS}
     \   Page Should Contain Element    xpath=//select[@id='form-widgets-slaveField${id}']/option[@value='${i}']
 
-Slave field '${id}' vocabulary should have text values ${possible_values}
+Slave field '${id}' vocabulary should '${not}' have text values ${possible_values}
     @{ITEMS} =    Split String    ${possible_values}    ,
     :FOR    ${i}    in    @{ITEMS}
-    \   Page Should Contain Element    xpath=//select[@id='form-widgets-slaveField${id}']/option[text()='${i}']
+    \   Run keyword    Page Should ${not} Contain Element    xpath=//select[@id='form-widgets-slaveField${id}']/option[text()='${i}']
 
 Slave master field should be visible
     Element should become visible    css=#formfield-form-widgets-slaveMasterField

--- a/plone/formwidget/masterselect/tests/robot/test_masterselect_demo.robot
+++ b/plone/formwidget/masterselect/tests/robot/test_masterselect_demo.robot
@@ -3,6 +3,7 @@ Resource        plone/app/robotframework/selenium.robot
 Resource        plone/app/robotframework/keywords.robot
 Library         Remote    ${PLONE_URL}/RobotRemote
 Library         String
+Library         plone/app/robotframework/i18n/I18N
 Variables       plone/app/testing/interfaces.py
 Test Setup      Open Test Browser
 Test Teardown   Close All browsers
@@ -68,6 +69,12 @@ Scenario: Master boolean field toggles visibility of slave field
      When I unselect the master boolean checkbox field
      Then Slave field '6' should not be visible
 
+Scenario: Master select field controls slave field vocabulary. Check if value is well translated.
+    Set default language  fr
+    Given I am on the masterselect demo page as a Manager
+     When I select 'ok' on master field 'form-widgets-masterField4'
+     Then Slave field '7' vocabulary should have text values Aucune valeur,ok
+    
 
 *** Keywords ***
 I am on the masterselect demo page as a ${role}
@@ -94,6 +101,11 @@ Slave field '${id}' vocabulary should have values ${possible_values}
     @{ITEMS} =    Split String    ${possible_values}    ,
     :FOR    ${i}    in    @{ITEMS}
     \   Page Should Contain Element    xpath=//select[@id='form-widgets-slaveField${id}']/option[@value='${i}']
+
+Slave field '${id}' vocabulary should have text values ${possible_values}
+    @{ITEMS} =    Split String    ${possible_values}    ,
+    :FOR    ${i}    in    @{ITEMS}
+    \   Page Should Contain Element    xpath=//select[@id='form-widgets-slaveField${id}']/option[text()='${i}']
 
 Slave master field should be visible
     Element should become visible    css=#formfield-form-widgets-slaveMasterField

--- a/plone/formwidget/masterselect/widget.py
+++ b/plone/formwidget/masterselect/widget.py
@@ -259,13 +259,9 @@ class MasterSelectJSONValue(BrowserView):
                 widget.update()
                 # widget may define items as a property or as a method
                 items = widget.items if not callable(widget.items) else widget.items()
-                # translate if possible. content can be a Message (ok), a string (UnicodeDecodeError), a unicode (ok)
-                # Message must not be decoded
+                # translate if possible. content can be a Message, a string, a unicode
                 for item in items:
-                    try:
-                        item['content'] = translate(item['content'], context=self.request)
-                    except:
-                        item['content'] = translate(safe_unicode(item['content']), context=self.request)
+                    item['content'] = translate(safe_unicode(item['content']), context=self.request)
                 responseJSON = {'items': items}
 
                 # disable select box if term length = 'disable_length'

--- a/plone/formwidget/masterselect/widget.py
+++ b/plone/formwidget/masterselect/widget.py
@@ -12,6 +12,7 @@ from z3c.form import interfaces
 from z3c.form.widget import FieldWidget
 from z3c.form.browser import select, checkbox, radio
 
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 
 from plone.formwidget.masterselect.interfaces import IMasterSelectField
@@ -258,6 +259,13 @@ class MasterSelectJSONValue(BrowserView):
                 widget.update()
                 # widget may define items as a property or as a method
                 items = widget.items if not callable(widget.items) else widget.items()
+                # translate if possible. content can be a Message (ok), a string (UnicodeDecodeError), a unicode (ok)
+                # Message must not be decoded
+                for item in items:
+                    try:
+                        item['content'] = translate(item['content'], context=self.request)
+                    except:
+                        item['content'] = translate(safe_unicode(item['content']), context=self.request)
                 responseJSON = {'items': items}
 
                 # disable select box if term length = 'disable_length'


### PR DESCRIPTION
When a vocabulary is managed by the master with the action 'vocabulary', the new vocabulary terms with optionally the special value 'No value' were not any more translated. 
Now it is ;-)
You can check this by commenting the new lines of widget.py and run again the tests.  