### PR TITLE
Make IMasterSelectField inherit from IField instead of IObject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- IMasterSelectField inherits from IField instead of IObject.
+  [wesleybl]
+
+
 - Use compile False in bundle.
   [wesleybl]
 

--- a/plone/formwidget/masterselect/interfaces.py
+++ b/plone/formwidget/masterselect/interfaces.py
@@ -1,8 +1,7 @@
+from z3c.form.i18n import MessageFactory as _
 from zope.interface import Interface
 from zope.schema import Tuple
-from zope.schema.interfaces import IObject
-
-from z3c.form.i18n import MessageFactory as _
+from zope.schema.interfaces import IField
 
 
 class IMasterSelectWidget(Interface):
@@ -20,22 +19,30 @@ class IMasterSelectRadioWidget(Interface):
     """
 
 
-class IMasterSelectField(IObject):
+class IMasterSelectField(IField):
     """
     Additional Fields for MasterSelect
     """
     slave_fields = Tuple(
-        title=_(u"title_slave_fields", default=u"Fields controlled by this field,"),
-        description=_(u"description_slave_fields", default=u"Fields controlled by this field, if control_type "
-                      "# is vocabulary only the first entry is used"),
+        title=_(
+            "title_slave_fields",
+            default=u"Fields controlled by this field,",
+        ),
+        description=_(
+            "description_slave_fields",
+            default=u"Fields controlled by this field, if control_type "
+            "# is vocabulary only the first entry is used",
+        ),
         default=(),
-        required=False
+        required=False,
     )
+
 
 class IMasterSelectBoolField(IMasterSelectField):
     """
     Additional Fields for MasterSelect
     """
+
 
 class IMasterSelectRadioField(IMasterSelectField):
     """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 
 version = '2.0.1.dev0'
 
@@ -47,6 +49,7 @@ setup(
         'setuptools',
         'z3c.form',
         'zope.component',
+        'zope.schema',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Fields that implement `IMasterSelectField` interface, inherit from `Choice` or `Bool`. Not from `Object`.

See: https://github.com/collective/plone.formwidget.masterselect/blob/5261b31af3e73f3b5d81becfca724571c6133e6e/plone/formwidget/masterselect/__init__.py#L16-L17