### PR TITLE
Fix interfaces implemented by fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Fix interfaces implemented by fields.
+  [wesleybl]
+
 - Use compile False in bundle.
   [wesleybl]
 

--- a/plone/formwidget/masterselect/__init__.py
+++ b/plone/formwidget/masterselect/__init__.py
@@ -1,31 +1,31 @@
-from zope.interface import implementer
-from zope.schema import Choice, Bool
-
-from plone.formwidget.masterselect.widget import MasterSelectWidget
-from plone.formwidget.masterselect.widget import MasterSelectFieldWidget
-from plone.formwidget.masterselect.widget import MasterSelectBoolFieldWidget
-from plone.formwidget.masterselect.widget import MasterSelectRadioFieldWidget
-
-from plone.formwidget.masterselect.interfaces import IMasterSelectField
 from plone.formwidget.masterselect.interfaces import IMasterSelectBoolField
+from plone.formwidget.masterselect.interfaces import IMasterSelectField
 from plone.formwidget.masterselect.interfaces import IMasterSelectRadioField
-
+from plone.formwidget.masterselect.widget import MasterSelectBoolFieldWidget
+from plone.formwidget.masterselect.widget import MasterSelectFieldWidget
+from plone.formwidget.masterselect.widget import MasterSelectRadioFieldWidget
+from plone.formwidget.masterselect.widget import MasterSelectWidget
 from zope.i18nmessageid import MessageFactory
+from zope.interface import implementer
+from zope.schema import Bool
+from zope.schema import Choice
+from zope.schema.interfaces import IChoice
+
+
 _ = MessageFactory("plone.formwidget.masterselect")
 
-@implementer(IMasterSelectField)
+
+@implementer(IMasterSelectField, IChoice)
 class MasterSelectField(Choice):
     """MasterSelectField that provides additional properties for widget
     (extends schema.Choice)
     """
     slave_fields = ()
 
-    def __init__(self,
-        slave_fields=(),
-        **kw
-    ):
+    def __init__(self, slave_fields=(), **kw):
         self.slave_fields = slave_fields
         super(MasterSelectField, self).__init__(**kw)
+
 
 @implementer(IMasterSelectBoolField)
 class MasterSelectBoolField(Bool):
@@ -34,12 +34,10 @@ class MasterSelectBoolField(Bool):
     """
     slave_fields = ()
 
-    def __init__(self,
-        slave_fields=(),
-        **kw
-    ):
+    def __init__(self, slave_fields=(), **kw):
         self.slave_fields = slave_fields
         super(MasterSelectBoolField, self).__init__(**kw)
+
 
 @implementer(IMasterSelectRadioField)
 class MasterSelectRadioField(Choice):
@@ -48,9 +46,6 @@ class MasterSelectRadioField(Choice):
     """
     slave_fields = ()
 
-    def __init__(self,
-        slave_fields=(),
-        **kw
-    ):
+    def __init__(self, slave_fields=(), **kw):
         self.slave_fields = slave_fields
         super(MasterSelectRadioField, self).__init__(**kw)

--- a/plone/formwidget/masterselect/interfaces.py
+++ b/plone/formwidget/masterselect/interfaces.py
@@ -1,8 +1,9 @@
+from z3c.form.i18n import MessageFactory as _
 from zope.interface import Interface
 from zope.schema import Tuple
-from zope.schema.interfaces import IObject
-
-from z3c.form.i18n import MessageFactory as _
+from zope.schema.interfaces import IBool
+from zope.schema.interfaces import IChoice
+from zope.schema.interfaces import IField
 
 
 class IMasterSelectWidget(Interface):
@@ -20,24 +21,32 @@ class IMasterSelectRadioWidget(Interface):
     """
 
 
-class IMasterSelectField(IObject):
+class IMasterSelectField(IField):
     """
     Additional Fields for MasterSelect
     """
     slave_fields = Tuple(
-        title=_(u"title_slave_fields", default=u"Fields controlled by this field,"),
-        description=_(u"description_slave_fields", default=u"Fields controlled by this field, if control_type "
-                      "# is vocabulary only the first entry is used"),
+        title=_(
+            "title_slave_fields",
+            default="Fields controlled by this field,",
+        ),
+        description=_(
+            "description_slave_fields",
+            default="Fields controlled by this field, if control_type "
+            "# is vocabulary only the first entry is used",
+        ),
         default=(),
-        required=False
+        required=False,
     )
 
-class IMasterSelectBoolField(IMasterSelectField):
+
+class IMasterSelectBoolField(IMasterSelectField, IBool):
     """
     Additional Fields for MasterSelect
     """
 
-class IMasterSelectRadioField(IMasterSelectField):
+
+class IMasterSelectRadioField(IMasterSelectField, IChoice):
     """
     MasterSelect radio button widget
     """

--- a/plone/formwidget/masterselect/tests/test_fields.py
+++ b/plone/formwidget/masterselect/tests/test_fields.py
@@ -1,0 +1,92 @@
+"""Tests of package fields."""
+from plone.formwidget.masterselect import MasterSelectBoolField
+from plone.formwidget.masterselect import MasterSelectField
+from plone.formwidget.masterselect import MasterSelectRadioField
+from plone.formwidget.masterselect.interfaces import IMasterSelectField
+from zope.schema.interfaces import IBool
+from zope.schema.interfaces import IChoice
+from zope.schema.interfaces import IField
+from zope.schema.interfaces import IObject
+
+import unittest
+
+
+class TestFields(unittest.TestCase):
+    """Test that plone.formwidget.masterselect fields is working."""
+
+    def test_ifield_providedby_masterselectfield(self):
+        self.assertTrue(
+            IField.providedBy(
+                MasterSelectField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_ichoice_providedby_masterselectfield(self):
+        self.assertTrue(
+            IChoice.providedBy(
+                MasterSelectField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_imasterselectfield_providedby_masterselectfield(self):
+        self.assertTrue(
+            IMasterSelectField.providedBy(
+                MasterSelectField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_iobject_not_providedby_masterselectfield(self):
+        self.assertFalse(
+            IObject.providedBy(
+                MasterSelectField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_ifield_providedby_masterselectboolfield(self):
+        self.assertTrue(
+            IField.providedBy(
+                MasterSelectBoolField(),
+            )
+        )
+
+    def test_ibool_providedby_masterselectboolfield(self):
+        self.assertTrue(
+            IBool.providedBy(
+                MasterSelectBoolField(),
+            )
+        )
+
+    def test_imasterselectfield_providedby_masterselectboolfield(self):
+        self.assertTrue(
+            IMasterSelectField.providedBy(
+                MasterSelectBoolField(),
+            )
+        )
+
+    def test_ifield_providedby_masterselectradiofield(self):
+        self.assertTrue(
+            IField.providedBy(
+                MasterSelectRadioField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_ichoice_providedby_masterselectradiofield(self):
+        self.assertTrue(
+            IChoice.providedBy(
+                MasterSelectRadioField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_imasterselectfield_providedby_masterselectradiofield(self):
+        self.assertTrue(
+            IMasterSelectField.providedBy(
+                MasterSelectRadioField(slave_fields=(), values=()),
+            )
+        )
+
+    def test_ibool_not_providedby_masterselectradiofield(self):
+        self.assertFalse(
+            IBool.providedBy(
+                MasterSelectRadioField(slave_fields=(), values=()),
+            )
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 
 version = '2.0.1.dev0'
 
@@ -47,6 +49,7 @@ setup(
         'setuptools',
         'z3c.form',
         'zope.component',
+        'zope.schema',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
- Fields that implement `IMasterSelectField` interface, inherit from `Choice` or `Bool`. So `IMasterSelectField` must inherit from `IField` and not `IObject`.

- Fields that implement `IMasterSelectBoolField` interface, inherit from `Bool`. So `IMasterSelectBoolField` must inherit from `IBool` also.

- Fields that implement `IMasterSelectRadioField` interface, inherit from `Choice`. So `IMasterSelectRadioField` must inherit from `IChoice` also.