### PR TITLE
Update Firefox to 102.6.0esr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       # Firefox
       - uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: '89.0'
+          firefox-version: '102.6.0esr'
       - run: firefox --version
 
       # python install


### PR DESCRIPTION
This fix error:

```
WebDriverException: Message: Process unexpectedly closed with status 0
```

Although tests with Python 3.7 are failing, the ideal is to remove support for Python 3.7 in another PR.